### PR TITLE
Fix exception when CommentsTemplate doesn't exist

### DIFF
--- a/Components/Templating/TemplateController.vb
+++ b/Components/Templating/TemplateController.vb
@@ -58,13 +58,10 @@ Namespace Templating
    Dim Template As String = Nothing
    Dim TemplateFileExistsLookup As Dictionary(Of String, Boolean) = GetTemplateFileLookupDictionary()
    If (Not TemplateFileExistsLookup.ContainsKey(cacheKey)) OrElse TemplateFileExistsLookup(cacheKey) Then
-    Dim filePath As String = Nothing
+    Dim filePath As String
     If cacheKey.Contains(":\") AndAlso Path.IsPathRooted(cacheKey) Then
-     If IO.File.Exists(cacheKey) Then
-      filePath = cacheKey
-     End If
-    End If
-    If filePath Is Nothing Then
+     filePath = cacheKey
+    Else
      filePath = System.Web.Hosting.HostingEnvironment.MapPath(ApplicationPath + cacheKey)
     End If
     If IO.File.Exists(filePath) Then


### PR DESCRIPTION
When using a template in the theme, the cache key when looking for the `CommentsTemplate.html` file is an absolute path with "backwards" slashes, e.g. `C:/inetpub/wwwroot/example.com/Portals/_default/Skins/example/Templates/Blog/example/CommentsTemplate.html`

When that doesn't exist, it was passed to `HostingEnvironment.MapPath`, which gave an exception at meeting such a path ("The relative virtual path 'C:/inetpub/…/CommentsTemplate.html' is not allowed here").

This commit avoid this by never passing a rooted path to `HostingEnvironment.MapPath`, and only doing the `File.Exists` check once.