### PR TITLE
Replace old references to Glyphicons with FontAwesome in _default skin

### DIFF
--- a/Templates/_default/Post.html
+++ b/Templates/_default/Post.html
@@ -16,11 +16,11 @@
       <div class="bg-danger">[resx:Unpublished]</div>
       [endif|1]
       <div>
-        <i class="glyphicon glyphicon-eye-open"></i>
+        <i class="fa fa-eye"></i>
         <div class="stat">[post:viewcount]</div>
       </div>
       <div>
-        <i class="glyphicon glyphicon-comment"></i>
+        <i class="fa fa-comment"></i>
         <div class="stat">[post:nrcomments]</div>
       </div>
     </div>


### PR DESCRIPTION
As described in Issue #102 , references to Glyphicons still exist in the
_default skin, although the project has migrated to using FontAwesome.

This fix replaces those references, causing the appropriate icon symbols
to appear at the bottom of each post listing.