### PR TITLE
Multiple tags run together on _default skin post listing

### DIFF
--- a/Templates/_default/Kw.html
+++ b/Templates/_default/Kw.html
@@ -1,1 +1,1 @@
-<span><a href="[term:link]" class="link-tag">[term:localizedname]</a></span>
+<span class="comma"><a href="[term:link]" class="link-tag">[term:localizedname]</a></span>


### PR DESCRIPTION
As discussed in issue #103, multiple tags assigned to a post are
displayed side-by-side with no spacing/punctuation between them on the
post listing.

This change causes multiple tags to be displayed with separating commas
and spaces, identically to how multiple categories are displayed.