### PR TITLE
Comment dialog too wide for some screens

### DIFF
--- a/Controls/Comments.ascx
+++ b/Controls/Comments.ascx
@@ -21,7 +21,7 @@ var $dialogComment;
 		 resizable: false,
 		 dialogClass: 'dnnFormPopup dnnClear',
 		 title: '<%=LocalizeJSString("CommentTitle") %>',
-		 width: 500,
+		 width: Math.min(500, $(window).width() * .95),
 		 open: function (e) {
 		  $('.ui-dialog-buttonpane').find('button:contains("<%=LocalizeJSString("Submit") %>")').addClass('dnnPrimaryAction');
 		  $('.ui-dialog-buttonpane').find('button:contains("<%=LocalizeJSString("Cancel") %>")').addClass('dnnSecondaryAction');


### PR DESCRIPTION
As discussed in issue #104 , the comments dialog box is too wide for some
mobile screens.

This change will reduce the width of the comments dialog to 95% of the
window width for browsers having less than 500px available to display
the dialog, while leaving the dialog box at the hard-coded width of
500px on all other devices.

Note: this width will only take effect when first displayed - it will
not cause the dialog box to dynamically resize if the browser window
resizes. However, most users (especially those on mobile devices) will
normally not resize the browser window (or rotate their device to a
different orientation) after displaying the dialog and beginning to
enter a comment.