### PR TITLE
Unauthenticated user names do not appear on comments (_default skin)

### DIFF
--- a/Templates/_default/Comment.html
+++ b/Templates/_default/Comment.html
@@ -4,6 +4,12 @@
       <img alt="[comment:displayname]" src="[commenter:profilepic|32]" />
     </div>
     <div class="profile">
+      <span id="anonDisplayName"></span>
+      <script>
+        if ([comment:createdbyuserid] == -1) {
+          document.getElementById("anonDisplayName").innerHTML='[comment:displayname]';
+        }
+      </script>
       <a href="[commenter:profileurl]">[commenter:displayname]</a>
     </div>
   </div>


### PR DESCRIPTION
As described in issue #105:

Whenever an unauthenticated (anonymous) user enters a comment, they are
required to enter a name (which could simply be an alias or one-time
screenname), but that name does not appear on the comment when the post
is displayed. Instead, only a placeholder icon for an unavailable
profile pic appears.

It seems that this name should be displayed, just as the display name
for an authenticated user is displayed on their comments. (Sometimes a
commenter may be a someone whose name is recognizable, but for whatever
reason, that person has chosen not to create a site login or has simply
decided to comment without logging in. In these cases, it is helpful to
see the name associated with the comment.)

The inline JavaScript addition works by making a couple of assumptions:
1. The comment's underlying CreatedByUserID field will always be set to -1 when a comment is added by an unauthenticated/anonymous user.
2. The old HTML code (which generates a link to the user profile) will always fail to generate any HTML for an unauthenticated/anonymous user (this code is always processed, but does not generate any visible HTML results).