### PR TITLE
Make list images link to posts (_default skin)

### DIFF
--- a/Templates/_default/ListImage.html
+++ b/Templates/_default/ListImage.html
@@ -1,4 +1,2 @@
-<picture>
-    <img title="[post:localizedtitle]" src="[settings:imagehandlerpath]?TabId=[module:tabid]&ModuleId=[module:moduleid]&Blog=[Post:blogid]&Post=[Post:contentitemid]&w=270&h=152&c=1&key=[Post:image]"
-    />
-</picture>
+<img title="[post:localizedtitle]" src="[settings:imagehandlerpath]?TabId=[module:tabid]&ModuleId=[module:moduleid]&Blog=[Post:blogid]&Post=[Post:contentitemid]&w=270&h=152&c=1&key=[Post:image]"
+/>

--- a/Templates/_default/Post.html
+++ b/Templates/_default/Post.html
@@ -1,9 +1,11 @@
 <article class="bbs-listarticle">
   <div class="supertitle">[subtemplate|Cat.html|categories]</div>
   <h2><a href="[Post:link]">[post:localizedtitle]</a></h2>
-  <figure>
-    [subtemplate|ListImage.html|post:hasimage]
-  </figure>
+  <a href="[Post:link]">
+    <figure>
+      [subtemplate|ListImage.html|post:hasimage]
+    </figure>
+  </a>
   <div class="content">
     <div class="summary">
       [post:localizedsummary]


### PR DESCRIPTION
Many popular blogs (ex: TechCrunch, Mashable) and news sites allow the user to click on the list image (thumbnail) to link to the full post, with the same results as if the user clicked on the title text. This is especially useful on mobile, where the image is usually a much larger target than the title.

This update to the _default skin adds the full post's link reference to the list image by wrapping the HTML figure tag.

A related change in the ListImage.html file: the HTML picture tag is removed, since it is not used/needed in this skin. The picture tag is designed/intended to specify multiple images of varying sizes, allowing the broswer to choose the most appropriate image to display based upon the browser's available window size. (A description of the picture tag with example can be found at  https://www.w3schools.com/tags/tag_picture.asp .) Since the DNN-Blog only allows a single image for the post, the picture tag is unnecessary.