### PR TITLE
Added error handling for empty categories

### DIFF
--- a/Admin.ascx
+++ b/Admin.ascx
@@ -208,7 +208,12 @@
  $(document).ready(function () {
   $('#categoryTree').dynatree({
    checkbox: false,
-   children: $.parseJSON($('#<%= treeState.ClientID %>').val()),
+   children: function () { 
+    if ($('#<%= treeState.ClientID %>').val() != "") {
+      return $.parseJSON($('#<%= treeState.ClientID %>').val());
+    }
+    else return null;
+   },
    dnd: {
     onDragStart: function (node) {
      return true;


### PR DESCRIPTION
### Description of PR...
Fix for issue when there are no categories specified and the jquery dynatree initialisation breaks, which subsequently fails to add categories as it is not defined.

## Changes made
- Wrapped "children" object in function which checks whether the target element value is an empty string, in which case it returns null.

## PR Template Checklist

- [x] Fixes Bug
- [ ] Feature solution
- [ ] Other

Close #122 #143 