### PR TITLE
Added support for canonical URLs for all pages (optional setting)

### DIFF
--- a/Server/Blog/Blog.ascx.vb
+++ b/Server/Blog/Blog.ascx.vb
@@ -107,26 +107,55 @@ Public Class Blog
 
    End If
 
-   If BlogContext.Post IsNot Nothing AndAlso BlogContext.Blog IsNot Nothing Then
-    AddOpenGraphMetaTags()
-    If BlogContext.Blog.EnablePingBackReceive Then
-     AddPingBackLink()
-    End If
-    If BlogContext.Blog.EnableTrackBackReceive Then
-     AddTrackBackBlurb()
-    End If
-   End If
+            If BlogContext.Post IsNot Nothing AndAlso BlogContext.Blog IsNot Nothing Then
+                AddOpenGraphMetaTags()
+                If ViewSettings.AddCanonicalTag Then
+                    AddCanonicalTag(True)
+                End If
+                If BlogContext.Blog.EnablePingBackReceive Then
+                    AddPingBackLink()
+                End If
+                If BlogContext.Blog.EnableTrackBackReceive Then
+                    AddTrackBackBlurb()
+                End If
+            Else
+                AddCanonicalTag(False)
+            End If
 
-   Context.Items("BlogPageInitialized") = True
+                Context.Items("BlogPageInitialized") = True
   End If
 
   DataBind()
 
  End Sub
+
+    Private Sub AddCanonicalTag(HasBlogContext As Boolean)
+        If BlogContext.Post IsNot Nothing Then
+            Page.Header.Controls.Add(New LiteralControl(String.Format("<link rel=""canonical"" href=""{0}"" />", BlogContext.Post.PermaLink)))
+        ElseIf BlogContext.Blog IsNot Nothing Then
+            Page.Header.Controls.Add(New LiteralControl(String.Format("<link rel=""canonical"" href=""{0}"" />", PortalSettings.Current.ActiveTab.FullUrl)))
+        ElseIf BlogContext.Author IsNot Nothing Then
+            Page.Header.Controls.Add(New LiteralControl(String.Format("<link rel=""canonical"" href=""{0}"" />", BlogContext.ModuleUrls.GetUrl(False, False, False, True, False))))
+        ElseIf BlogContext.Term IsNot Nothing Then
+            Page.Header.Controls.Add(New LiteralControl(String.Format("<link rel=""canonical"" href=""{0}"" />", BlogContext.Term.PermaLink(PortalSettings))))
+        Else
+            Page.Header.Controls.Add(New LiteralControl(String.Format("<link rel=""canonical"" href=""{0}"" />", PortalSettings.Current.ActiveTab.FullUrl)))
+        End If
+        If HasBlogContext Then
+
+        ElseIf Not HasBlogContext And BlogContext.Term IsNot Nothing Then
+
+        ElseIf Not HasBlogContext And BlogContext.Author IsNot Nothing Then
+
+        Else
+
+        End If
+    End Sub
+
 #End Region
 
 #Region " Open Graph Meta Tags "
- Private Sub AddOpenGraphMetaTags()
+    Private Sub AddOpenGraphMetaTags()
   Dim URL As String = HttpContext.Current.Request.Url.Scheme + "://" + HttpContext.Current.Request.Url.Host
     Page.Header.Controls.Add(New LiteralControl(String.Format("<meta id=""ogurl"" property=""og:url"" content=""{0}"" />", BlogContext.Post.PermaLink)))
     Page.Header.Controls.Add(New LiteralControl(String.Format("<meta content=""{0}"" name=""twitter:url"">", BlogContext.Post.PermaLink)))

--- a/Server/Blog/Components/Common/ViewSettings.vb
+++ b/Server/Blog/Components/Common/ViewSettings.vb
@@ -35,8 +35,9 @@ Namespace Common
   Public Property Template As String = "[G]_default"
   Public Property BlogModuleId As Integer = -1
   Public Property ShowAllLocales As Boolean = True
-  Public Property ModifyPageDetails As Boolean = False
-  Public Property ShowManagementPanel As Boolean = False
+        Public Property ModifyPageDetails As Boolean = False
+        Public Property AddCanonicalTag As Boolean = False
+        Public Property ShowManagementPanel As Boolean = False
   Public Property ShowManagementPanelViewMode As Boolean = True
   Public Property HideUnpublishedBlogsViewMode As Boolean = False
   Public Property HideUnpublishedBlogsEditMode As Boolean = False
@@ -78,8 +79,9 @@ Namespace Common
    _allSettings.ReadValue("Template", Template)
    _allSettings.ReadValue("BlogModuleId", BlogModuleId)
    _allSettings.ReadValue("ShowAllLocales", ShowAllLocales)
-   _allSettings.ReadValue("ModifyPageDetails", ModifyPageDetails)
-   _allSettings.ReadValue("ShowManagementPanel", ShowManagementPanel)
+            _allSettings.ReadValue("ModifyPageDetails", ModifyPageDetails)
+            _allSettings.ReadValue("AddCanonicalTag", AddCanonicalTag)
+            _allSettings.ReadValue("ShowManagementPanel", ShowManagementPanel)
    _allSettings.ReadValue("ShowManagementPanelViewMode", ShowManagementPanelViewMode)
    _allSettings.ReadValue("HideUnpublishedBlogsViewMode", HideUnpublishedBlogsViewMode)
    _allSettings.ReadValue("HideUnpublishedBlogsEditMode", HideUnpublishedBlogsEditMode)
@@ -124,8 +126,9 @@ Namespace Common
    objModules.UpdateTabModuleSetting(tabModuleId, "Template", Template)
    objModules.UpdateTabModuleSetting(tabModuleId, "BlogModuleId", BlogModuleId.ToString)
    objModules.UpdateTabModuleSetting(tabModuleId, "ShowAllLocales", ShowAllLocales.ToString)
-   objModules.UpdateTabModuleSetting(tabModuleId, "ModifyPageDetails", ModifyPageDetails.ToString)
-   objModules.UpdateTabModuleSetting(tabModuleId, "ShowManagementPanel", ShowManagementPanel.ToString)
+            objModules.UpdateTabModuleSetting(tabModuleId, "ModifyPageDetails", ModifyPageDetails.ToString)
+            objModules.UpdateTabModuleSetting(tabModuleId, "AddCanonicalTag", AddCanonicalTag.ToString)
+            objModules.UpdateTabModuleSetting(tabModuleId, "ShowManagementPanel", ShowManagementPanel.ToString)
    objModules.UpdateTabModuleSetting(tabModuleId, "ShowManagementPanelViewMode", ShowManagementPanelViewMode.ToString)
    objModules.UpdateTabModuleSetting(tabModuleId, "HideUnpublishedBlogsViewMode", HideUnpublishedBlogsViewMode.ToString)
    objModules.UpdateTabModuleSetting(tabModuleId, "HideUnpublishedBlogsEditMode", HideUnpublishedBlogsEditMode.ToString)
@@ -224,8 +227,9 @@ Namespace Common
    writer.WriteElementString("Template", Template)
    writer.WriteElementString("BlogModuleId", BlogModuleId.ToString)
    writer.WriteElementString("ShowAllLocales", ShowAllLocales.ToString)
-   writer.WriteElementString("ModifyPageDetails", ModifyPageDetails.ToString)
-   writer.WriteElementString("ShowManagementPanel", ShowManagementPanel.ToString)
+            writer.WriteElementString("ModifyPageDetails", ModifyPageDetails.ToString)
+            writer.WriteElementString("AddCanonicalTag", AddCanonicalTag.ToString)
+            writer.WriteElementString("ShowManagementPanel", ShowManagementPanel.ToString)
    writer.WriteElementString("ShowManagementPanelViewMode", ShowManagementPanelViewMode.ToString)
    writer.WriteElementString("HideUnpublishedBlogsViewMode", HideUnpublishedBlogsViewMode.ToString)
    writer.WriteElementString("HideUnpublishedBlogsEditMode", HideUnpublishedBlogsEditMode.ToString)
@@ -240,8 +244,9 @@ Namespace Common
    xml.ReadValue("Template", Template)
    xml.ReadValue("BlogModuleId", BlogModuleId)
    xml.ReadValue("ShowAllLocales", ShowAllLocales)
-   xml.ReadValue("ModifyPageDetails", ModifyPageDetails)
-   xml.ReadValue("ShowManagementPanel", ShowManagementPanel)
+            xml.ReadValue("ModifyPageDetails", ModifyPageDetails)
+            xml.ReadValue("AddCanonicalTag", AddCanonicalTag)
+            xml.ReadValue("ShowManagementPanel", ShowManagementPanel)
    xml.ReadValue("ShowManagementPanelViewMode", ShowManagementPanelViewMode)
    xml.ReadValue("HideUnpublishedBlogsViewMode", HideUnpublishedBlogsViewMode)
    xml.ReadValue("HideUnpublishedBlogsEditMode", HideUnpublishedBlogsEditMode)

--- a/Server/Blog/Controls/App_LocalResources/ViewSettings.ascx.resx
+++ b/Server/Blog/Controls/App_LocalResources/ViewSettings.ascx.resx
@@ -195,4 +195,10 @@
   <data name="lblAllowComments.Text" xml:space="preserve">
     <value>Allow Comments</value>
   </data>
+  <data name="lblAddCanonicalTag.Help" xml:space="preserve">
+    <value>When checked, a canonical tag will be added to the page to help improve SEO for this website.  </value>
+  </data>
+  <data name="lblAddCanonicalTag.Text" xml:space="preserve">
+    <value>Add Canonical Tag</value>
+  </data>
 </root>

--- a/Server/Blog/Controls/ViewSettings.ascx
+++ b/Server/Blog/Controls/ViewSettings.ascx
@@ -34,6 +34,10 @@
         <asp:CheckBox ID="chkModifyPageDetails" runat="server" />
     </div>
     <div class="dnnFormItem">
+        <dnn:label id="lblAddCanonicalTag" runat="server" controlname="chkAddCanonicalTag" suffix=":" />
+        <asp:CheckBox ID="chkAddCanonicalTag" runat="server" />
+    </div>
+    <div class="dnnFormItem">
         <dnn:label id="lblShowManagementPanel" runat="server" controlname="chkShowManagementPanel" suffix=":" />
         <asp:CheckBox ID="chkShowManagementPanel" runat="server" ResourceKey="chkShowManagementPanel" />
         <asp:CheckBox ID="chkShowManagementPanelViewMode" runat="server" ResourceKey="chkShowManagementPanelViewMode" />

--- a/Server/Blog/Controls/ViewSettings.ascx.designer.vb
+++ b/Server/Blog/Controls/ViewSettings.ascx.designer.vb
@@ -11,9 +11,9 @@ Option Strict On
 Option Explicit On
 
 Namespace Controls
-    
+
     Partial Public Class ViewSettings
-        
+
         '''<summary>
         '''lblBlogModuleId control.
         '''</summary>
@@ -22,7 +22,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents lblBlogModuleId As Global.System.Web.UI.UserControl
-        
+
         '''<summary>
         '''ddBlogModuleId control.
         '''</summary>
@@ -31,7 +31,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents ddBlogModuleId As Global.System.Web.UI.WebControls.DropDownList
-        
+
         '''<summary>
         '''lblBlogId control.
         '''</summary>
@@ -40,7 +40,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents lblBlogId As Global.System.Web.UI.UserControl
-        
+
         '''<summary>
         '''ddBlogId control.
         '''</summary>
@@ -49,7 +49,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents ddBlogId As Global.System.Web.UI.WebControls.DropDownList
-        
+
         '''<summary>
         '''pnlCategories control.
         '''</summary>
@@ -58,7 +58,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents pnlCategories As Global.System.Web.UI.WebControls.Panel
-        
+
         '''<summary>
         '''lblCategories control.
         '''</summary>
@@ -67,7 +67,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents lblCategories As Global.System.Web.UI.UserControl
-        
+
         '''<summary>
         '''ctlCategories control.
         '''</summary>
@@ -76,7 +76,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents ctlCategories As Global.DotNetNuke.Modules.Blog.Controls.CategorySelect
-        
+
         '''<summary>
         '''lblAuthorId control.
         '''</summary>
@@ -85,7 +85,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents lblAuthorId As Global.System.Web.UI.UserControl
-        
+
         '''<summary>
         '''ddAuthorId control.
         '''</summary>
@@ -94,7 +94,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents ddAuthorId As Global.System.Web.UI.WebControls.DropDownList
-        
+
         '''<summary>
         '''lblTemplate control.
         '''</summary>
@@ -103,7 +103,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents lblTemplate As Global.System.Web.UI.UserControl
-        
+
         '''<summary>
         '''ddTemplate control.
         '''</summary>
@@ -112,7 +112,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents ddTemplate As Global.System.Web.UI.WebControls.DropDownList
-        
+
         '''<summary>
         '''lblShowAllLocales control.
         '''</summary>
@@ -121,7 +121,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents lblShowAllLocales As Global.System.Web.UI.UserControl
-        
+
         '''<summary>
         '''chkShowAllLocales control.
         '''</summary>
@@ -130,7 +130,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents chkShowAllLocales As Global.System.Web.UI.WebControls.CheckBox
-        
+
         '''<summary>
         '''lblModifyPageDetails control.
         '''</summary>
@@ -139,7 +139,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents lblModifyPageDetails As Global.System.Web.UI.UserControl
-        
+
         '''<summary>
         '''chkModifyPageDetails control.
         '''</summary>
@@ -148,7 +148,25 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents chkModifyPageDetails As Global.System.Web.UI.WebControls.CheckBox
-        
+
+        '''<summary>
+        '''lblAddCanonicalTag control.
+        '''</summary>
+        '''<remarks>
+        '''Auto-generated field.
+        '''To modify move field declaration from designer file to code-behind file.
+        '''</remarks>
+        Protected WithEvents lblAddCanonicalTag As Global.System.Web.UI.UserControl
+
+        '''<summary>
+        '''chkAddCanonicalTag control.
+        '''</summary>
+        '''<remarks>
+        '''Auto-generated field.
+        '''To modify move field declaration from designer file to code-behind file.
+        '''</remarks>
+        Protected WithEvents chkAddCanonicalTag As Global.System.Web.UI.WebControls.CheckBox
+
         '''<summary>
         '''lblShowManagementPanel control.
         '''</summary>
@@ -157,7 +175,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents lblShowManagementPanel As Global.System.Web.UI.UserControl
-        
+
         '''<summary>
         '''chkShowManagementPanel control.
         '''</summary>
@@ -166,7 +184,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents chkShowManagementPanel As Global.System.Web.UI.WebControls.CheckBox
-        
+
         '''<summary>
         '''chkShowManagementPanelViewMode control.
         '''</summary>
@@ -175,7 +193,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents chkShowManagementPanelViewMode As Global.System.Web.UI.WebControls.CheckBox
-        
+
         '''<summary>
         '''lblHideUnpublishedBlogs control.
         '''</summary>
@@ -184,7 +202,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents lblHideUnpublishedBlogs As Global.System.Web.UI.UserControl
-        
+
         '''<summary>
         '''chkHideUnpublishedBlogsViewMode control.
         '''</summary>
@@ -193,7 +211,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents chkHideUnpublishedBlogsViewMode As Global.System.Web.UI.WebControls.CheckBox
-        
+
         '''<summary>
         '''chkHideUnpublishedBlogsEditMode control.
         '''</summary>
@@ -202,7 +220,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents chkHideUnpublishedBlogsEditMode As Global.System.Web.UI.WebControls.CheckBox
-        
+
         '''<summary>
         '''lblAllowComments control.
         '''</summary>
@@ -211,7 +229,7 @@ Namespace Controls
         '''To modify move field declaration from designer file to code-behind file.
         '''</remarks>
         Protected WithEvents lblAllowComments As Global.System.Web.UI.UserControl
-        
+
         '''<summary>
         '''chkAllowComments control.
         '''</summary>

--- a/Server/Blog/Controls/ViewSettings.ascx.vb
+++ b/Server/Blog/Controls/ViewSettings.ascx.vb
@@ -166,8 +166,9 @@ Namespace Controls
    End If
 
    chkShowAllLocales.Checked = ViewSettings.ShowAllLocales
-   chkModifyPageDetails.Checked = ViewSettings.ModifyPageDetails
-   chkShowManagementPanel.Checked = ViewSettings.ShowManagementPanel
+            chkModifyPageDetails.Checked = ViewSettings.ModifyPageDetails
+            chkAddCanonicalTag.Checked = ViewSettings.AddCanonicalTag
+            chkShowManagementPanel.Checked = ViewSettings.ShowManagementPanel
    chkShowManagementPanelViewMode.Checked = ViewSettings.ShowManagementPanelViewMode
 
    chkHideUnpublishedBlogsViewMode.Checked = ViewSettings.HideUnpublishedBlogsViewMode
@@ -186,8 +187,9 @@ Namespace Controls
 
    ViewSettings.BlogModuleId = CInt(ddBlogModuleId.SelectedValue)
    ViewSettings.ShowAllLocales = chkShowAllLocales.Checked
-   ViewSettings.ModifyPageDetails = chkModifyPageDetails.Checked
-   ViewSettings.ShowManagementPanel = chkShowManagementPanel.Checked
+            ViewSettings.ModifyPageDetails = chkModifyPageDetails.Checked
+            ViewSettings.AddCanonicalTag = chkAddCanonicalTag.Checked
+            ViewSettings.ShowManagementPanel = chkShowManagementPanel.Checked
    ViewSettings.ShowManagementPanelViewMode = chkShowManagementPanelViewMode.Checked
    ViewSettings.HideUnpublishedBlogsViewMode = chkHideUnpublishedBlogsViewMode.Checked
    ViewSettings.HideUnpublishedBlogsEditMode = chkHideUnpublishedBlogsEditMode.Checked


### PR DESCRIPTION
### Description of PR...

## Changes made
- Added a module setting to toggle canonical support 
- When enabled, adds the canonical tag to the page for the normal blog page, author page, terms/tags page, and the post itself 


## PR Template Checklist

- [ ] Fixes Bug
- [x] Feature solution
- [ ] Other


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #180 