### PR TITLE
Fix blog chooser dialog styling on DNN 10

### DIFF
--- a/Server/Blog/Controls/ManagementPanel.ascx
+++ b/Server/Blog/Controls/ManagementPanel.ascx
@@ -139,9 +139,17 @@
 		 title: '<%=LocalizeJSString("BlogChoose") %>',
 		 width: 500,
 		 open: function (e) {
-		  $('.ui-dialog-buttonpane').find('button:contains("<%=LocalizeJSString("cmdBlog") %>")').addClass('dnnPrimaryAction');
-		  $('.ui-dialog-buttonpane').find('button:contains("<%=LocalizeJSString("Cancel") %>")').addClass('dnnSecondaryAction');
-    $('#<%:ClientID%>ddBlog').width("100%");
+		  var $dialogWidget = $(this).dialog('widget');
+
+		  $dialogWidget.addClass('dnnFormPopup dnnClear dnnBlogChoosePopup');
+
+		  var $buttonPane = $dialogWidget.find('.ui-dialog-buttonpane');
+		  $buttonPane.find('button:contains("<%=LocalizeJSString("cmdBlog") %>")').addClass('dnnPrimaryAction');
+		  $buttonPane.find('button:contains("<%=LocalizeJSString("Cancel") %>")').addClass('dnnSecondaryAction');
+    $('#<%:ClientID%>ddBlog').css({
+     width: '100%',
+     boxSizing: 'border-box'
+    });
 		 },
 		 buttons: [
     {


### PR DESCRIPTION
Summary

Fixes the malformed blog-selection dialog that appears when a user clicks New Post! and more than one blog is configured.

The chooser content was generated correctly, including the blog selector and action buttons, but under DNN 10 the required DNN popup classes were not reliably applied to the generated jQuery UI dialog wrapper. This caused the chooser controls to appear as unstyled page content instead of inside a properly formed popup.

Changes

This pull request updates:

Server/Blog/Controls/ManagementPanel.ascx

The repair:

obtains the generated jQuery UI dialog widget directly when the chooser opens;
applies dnnFormPopup, dnnClear, and dnnBlogChoosePopup directly to the generated dialog wrapper;
retains the existing dialogClass setting for compatibility;
scopes button-pane styling to the current blog chooser dialog instead of searching globally across the page;
preserves the existing primary and secondary action button styling;
sets the blog selector to width: 100% with box-sizing: border-box;
prevents the selector’s right edge and drop-down arrow from being clipped;
leaves the existing blog-selection and post-navigation logic unchanged.
Before

When multiple blogs were configured and New Post! was selected:

the blog chooser title appeared outside a popup;
the blog selector appeared as unstyled page content;
the New Post and Cancel buttons were not contained within a properly styled dialog;
the selector’s drop-down arrow could be partially clipped.
After

The blog chooser now:

forms as a properly styled DNN popup;
appears centred on the screen;
contains the title, selector, and action buttons correctly;
displays the full blog selector and drop-down arrow;
allows the user to select the intended blog;
closes correctly when Cancel is selected;
proceeds to the correct post editor when New Post is selected.
Testing

The repair was tested successfully on:

DNN Platform 9.13.1 development site;
DNN Platform 10.3.2 development site;
DNN Platform 10.3.2 production site.

The following scenarios were verified:

opening the chooser when multiple blogs are configured;
selecting between available blogs;
creating a new post for the selected blog;
cancelling and closing the chooser;
correct popup positioning and styling;
full visibility of the selector and its drop-down arrow.

No server-side code, blog permissions, blog data, or navigation logic was changed.
## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #229